### PR TITLE
Createslip05

### DIFF
--- a/app/Domain/Factory/Impl/StockFactoryImpl.php
+++ b/app/Domain/Factory/Impl/StockFactoryImpl.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\Factory\Impl;
+
+use App\Domain\Factory\StockFactory;
+use App\Domain\Repository\StockRepository;
+
+class StockFactoryImpl implements StockFactory{
+
+    
+    private StockRepository $repository;
+
+    public function __construct(StockRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+    
+
+    public function getStock(string $itemName, string $warehouseName){
+
+        // リポジトリから取得する。
+        $stock =$this->repository->getStockByName($itemName,$warehouseName);
+
+    }
+
+}

--- a/app/Domain/Factory/StockFactory.php
+++ b/app/Domain/Factory/StockFactory.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Domain\Factory;
+
+interface StockFactory{
+    public function getStock(string $itemName, string $warehouseName);
+}

--- a/app/Domain/Logic/Rule/EntryExit/TransactionCombinationRule.php
+++ b/app/Domain/Logic/Rule/EntryExit/TransactionCombinationRule.php
@@ -26,6 +26,7 @@ class TransactionCombinationRule implements Rule
             {
                 if($detail->getDetailDiv() === "出庫" || $detail->getDetailDiv() === "破棄"){
                     array_push($messages,["伝票と明細の取引区分が不正です。"]);
+                    array_push($messages,["試しに2つ目のエラーメッセージを投入"]);
                 }
             }
         }

--- a/app/Domain/Logic/Rule/EntryExit/VaildCountRule.php
+++ b/app/Domain/Logic/Rule/EntryExit/VaildCountRule.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Domain\Logic\Rule\EntryExit;
+
+use App\Domain\Logic\Rule\Rule;
+use App\Domain\Model\Entity\EntryExitSlip;
+
+class VaildCountRule implements Rule
+{
+
+    private EntryExitSlip $slip;
+
+    public function __construct(EntryExitSlip $slip)
+    {
+        $this->slip = $slip;
+    }
+
+    public function vaild(): array
+    {
+
+        $messages = array();
+
+        foreach($this->slip->getDetails() as $detail)
+        {
+            if(!$detail->isExpectedCount())
+            {
+                array_push($messages,["明細区分と数量の整合性が不正です"]);
+            }
+        }
+
+        return $messages;
+
+    }
+
+}

--- a/app/Domain/Logic/Validation/EntryExitCreateValidation.php
+++ b/app/Domain/Logic/Validation/EntryExitCreateValidation.php
@@ -41,13 +41,12 @@ class EntryExitCreateValidation
             //$result = array_merge($this->message,$vaildResult);
         }
 
-
         if(count($result) !== 0)
         {
-            Redirect::route('entryexitcreate')->withErrors(['messages' => $result, 'result' => "エラーがあります"])->withInput()->throwResponse();;
+            Redirect::route('entryexitcreate')->with(["messages" => $result])->withErrors(['result' => "エラーがあります"])->withInput()->throwResponse();;
         }
 
-        dd($result);
+        dd("在庫数のチェックへ");
 
     }
 

--- a/app/Domain/Logic/Validation/EntryExitCreateValidation.php
+++ b/app/Domain/Logic/Validation/EntryExitCreateValidation.php
@@ -3,6 +3,8 @@
 namespace App\Domain\Logic\Validation;
 
 use App\Domain\Logic\Rule\EntryExit\TransactionCombinationRule;
+use App\Domain\Logic\Rule\EntryExit\VaildCountRule;
+use App\Domain\Logic\Rule\Rule;
 use App\Domain\Model\Entity\EntryExitSlip;
 use Illuminate\Support\Facades\Redirect;
 
@@ -11,34 +13,20 @@ class EntryExitCreateValidation
 
     private array $rules = array();
 
-    private array $message = array();
-
-    private EntryExitSlip $slip;
-
     public function __construct(EntryExitSlip $slip)
     {
-        $this->slip = $slip;
-
-        array_push($this->rules,[
-            new TransactionCombinationRule($slip),
-        ]);
+        $this->addRule(new TransactionCombinationRule($slip));
+        $this->addRule(new VaildCountRule($slip));
     }
 
     public function execute()
     {
-
-        // TODO 実装方法があり次第修正する
-        $rule = new TransactionCombinationRule($this->slip);
-        $vaildResult = $rule->vaild();
-
-        $result = array_merge($this->message,$vaildResult);
+        $result = array();
 
         foreach($this->rules as $rule)
         {
-
-            // Javaのようにできないので一旦、保留の処理になっています。
-            // $vaildResult = $rule->vaild();
-            //$result = array_merge($this->message,$vaildResult);
+            $vaildResult = $rule->vaild();
+            $result = [...$result, ...$vaildResult];
         }
 
         if(count($result) !== 0)
@@ -46,8 +34,18 @@ class EntryExitCreateValidation
             Redirect::route('entryexitcreate')->with(["messages" => $result])->withErrors(['result' => "エラーがあります"])->withInput()->throwResponse();;
         }
 
-        dd("在庫数のチェックへ");
+    }
 
+
+
+    //　基底切り出しなどしても良い
+    /**
+     * 型の限定を行う。
+     * こうしないとarray型からメソッド呼出しを行う行為になってしまう(array->function())
+     */
+    private function addRule(Rule $rule)
+    {
+        array_push($this->rules,$rule);
     }
 
 }

--- a/app/Domain/Model/Entity/EntryExitDetail.php
+++ b/app/Domain/Model/Entity/EntryExitDetail.php
@@ -19,7 +19,6 @@ class EntryExitDetail extends Detail{
 
     private string $unit;
 
-
     public function setEntryExitNo(int $no)
     {
         $this->entryexitNo = $no;
@@ -79,5 +78,30 @@ class EntryExitDetail extends Detail{
     {
         return $this->warehouseName;
     }
+
+    /**
+     * 明細区分と数量の整合性を検証します
+     */
+    public function isExpectedCount(): bool
+    {
+        // todo refactor use types
+        if($this->detailDiv === "入庫" || $this->detailDiv === "返品")
+        {
+            if($this->count <= 0){
+                return false;
+            }
+        }
+
+        if($this->detailDiv === "出庫" || $this->detailDiv === "破棄")
+        {
+            if($this->count >= 0){
+                return false;
+            }
+        }
+
+        return true;
+
+    }
+
 
 }

--- a/app/Domain/Model/Entity/Item.php
+++ b/app/Domain/Model/Entity/Item.php
@@ -4,10 +4,8 @@ namespace App\Domain\Model\Entity;
 
 use App\Domain\Model\ValueObject\Price;
 
-
 class Item
 {
-
     private string $name;
 
     private Price $price;

--- a/app/Domain/Model/Entity/Stock.php
+++ b/app/Domain/Model/Entity/Stock.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Domain\Model\Entity;
+
+
+class Stock
+{
+    private string $itemName;
+
+    private string $warehouseName;
+
+    private int $count;
+
+    public function canExit(int $exitCount)
+    {
+        if($this->count - $exitCount < 0)
+        {
+            return false;
+        }
+        return true;
+    }
+
+    public function setItenName(string $name)
+    {
+        $this->itemName = $name;
+    }
+
+    public function getItemName()
+    {
+        return $this->itemName;
+    }
+
+    
+    public function setWarehouseName(string $name)
+    {
+        $this->warehouseName = $name;
+    }
+
+    public function getWarehouseName()
+    {
+        return $this->warehouseName;
+    }
+
+    public function setCount(string $count)
+    {
+        $this->count = $count;
+    }
+
+    public function getCount()
+    {
+        return $this->count;
+    }
+
+
+}

--- a/app/Domain/Model/ValueObject/EntryExitDiv.php
+++ b/app/Domain/Model/ValueObject/EntryExitDiv.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Domain\Model\ValueObject;
+
+class EntryExitDiv{
+    
+}

--- a/app/Domain/Repository/StockRepository.php
+++ b/app/Domain/Repository/StockRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Domain\Repository;
+
+
+interface StockRepository
+{
+    public function getStockByName(string $itemName, string $warehouoseName);
+}

--- a/app/Domain/Service/Impl/EntryExitServiceImpl.php
+++ b/app/Domain/Service/Impl/EntryExitServiceImpl.php
@@ -8,21 +8,25 @@ use App\Domain\Model\Entity\EntryExitDetail;
 use App\Domain\Model\Entity\EntryExitSlip;
 use App\Domain\Repository\NumberingRepository;
 use App\Domain\Service\EntryExitService;
+use App\Domain\Service\StockService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 
 class EntryExitServiceImpl implements EntryExitService
 {
 
-
     private EntryExitCreationLogic $createtionLogic;
 
     private NumberingRepository $numberRepository;
 
-    public function __construct(EntryExitCreationLogic $logic, NumberingRepository $numberRepository)
+    private StockService $stockService;
+
+    public function __construct(EntryExitCreationLogic $logic, 
+        NumberingRepository $numberRepository,StockService $stockService)
     {
         $this->createtionLogic = $logic;
         $this->numberRepository = $numberRepository;
+        $this->stockService = $stockService;
     }
 
     public function create(Request $request)
@@ -55,6 +59,24 @@ class EntryExitServiceImpl implements EntryExitService
         $validationLogic->execute();
 
         // 在庫数のチェック
+
+        // 在庫モデルを作成します。
+        // DTO的なものを作りたい。（数量をマイナス登録したほうがよいのでは？）
+
+        
+        $this->stockService->update($detail->getItemName(), $detail->getWarehouseName());
+
+        dd("ok");
+
+        // 在庫モデルをUpdateに引き渡します。
+        // updateで検証を行います。
+            // 検証内容は、在庫モデルの数量が出庫数で-になったらだめ
+
+            // 出庫をupdateします。
+
+        // Lets gooo!!! buuuuooooonnn!!!
+        
+        // stockは既にある場合もあれば無い場合もあるので別途取得します。
 
 
         // 永続化処理

--- a/app/Domain/Service/Impl/StockServiceImpl.php
+++ b/app/Domain/Service/Impl/StockServiceImpl.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Domain\Service\Impl;
+
+use App\Domain\Factory\StockFactory;
+use App\Domain\Service\StockService;
+
+class StockServiceImpl implements StockService
+{
+    
+    private StockFactory $stockFactory;
+
+    public function __construct(StockFactory $factory)
+    {
+        $this->stockFactory = $factory;
+    }
+
+    public function update(string $itemName, string $warehouoseName)
+    {
+       $model = $this->stockFactory->getStock($itemName,$warehouoseName);
+    }
+}

--- a/app/Domain/Service/StockService.php
+++ b/app/Domain/Service/StockService.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Domain\Service;
+
+interface StockService
+{
+    public function update(string $itemName, string $warehouoseName);
+}

--- a/app/Domain/Type/EntryExitDiv.php
+++ b/app/Domain/Type/EntryExitDiv.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Domain\Type;
+
+// PHPにEnumがない。。。

--- a/app/Infrastructure/Repository/EloquentStockRepositoryImpl.php
+++ b/app/Infrastructure/Repository/EloquentStockRepositoryImpl.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Infrastructure\Repository;
+
+use App\Domain\Model\Entity\Stock;
+use App\Domain\Repository\StockRepository;
+use App\Models\Stock as ModelsStock;
+
+use function PHPUnit\Framework\isEmpty;
+
+class EloquentStockRepositoryImpl implements StockRepository{
+
+    public function getStockByName(string $itemName, string $warehouoseName)
+    {
+        $stock = new Stock();
+
+        $modelStock = ModelsStock::where('item_name', $itemName)->where('warehouse_name', $warehouoseName)->get();
+        
+        // todo refactor
+        // 戻り値がCollectionです
+        if($modelStock->isEmpty())
+        {
+            $stock->setItenName($itemName);
+            $stock->setWarehouseName($warehouoseName);
+            $stock->setCount(0);
+            return $stock;
+        }
+
+        dd($modelStock);
+        $stock->setItenName($modelStock->item_name);
+        $stock->setWarehouseName($modelStock->warehouse_name);
+        $stock->setCount($modelStock->itemcount_name);
+
+        return $stock;
+
+    }
+
+}

--- a/app/Providers/StockServiceProvider.php
+++ b/app/Providers/StockServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Providers;
+
+use App\Domain\Factory\Impl\StockFactoryImpl;
+use App\Domain\Factory\StockFactory;
+use App\Domain\Repository\StockRepository;
+use App\Domain\Service\Impl\StockServiceImpl;
+use App\Domain\Service\StockService;
+use App\Infrastructure\Repository\EloquentStockRepositoryImpl;
+use Illuminate\Support\ServiceProvider;
+
+class StockServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+        $this->app->bind(StockFactory::class, StockFactoryImpl::class);
+        $this->app->bind(StockService::class, StockServiceImpl::class);
+        $this->app->bind(StockRepository::class, EloquentStockRepositoryImpl::class);
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -179,6 +179,7 @@ return [
         App\Providers\WarehouseServiceProvider::class,
         App\Providers\ComboboxServiceProvider::class,
         App\Providers\EntryExitServiceProvider::class,
+        App\Providers\StockServiceProvider::class,
     ],
 
     /*

--- a/database/migrations/2021_11_08_053153_create_stocks_table.php
+++ b/database/migrations/2021_11_08_053153_create_stocks_table.php
@@ -19,7 +19,7 @@ class CreateStocksTable extends Migration
             $table->string('warehouse_name');
             $table->integer('item_id');
             $table->string('item_name');
-            $table->integer('amount');
+            $table->integer('count');
             $table->timestamps();
         });
     }

--- a/resources/views/slip/create.blade.php
+++ b/resources/views/slip/create.blade.php
@@ -31,8 +31,17 @@
                 @foreach($errors->get("result") as $error)
                     <li>{{ $error }}</li>
                 @endforeach
+
+                @foreach(session('messages') as $messages)
+                    @foreach($messages as $message)
+                        <li>{{ $message }}</li>
+                    @endforeach
+                @endforeach
+
             </ul>
             @endif
+
+            
         </div>
 
         <form name="registerform" action="/entryexit/store" method="post" id="registerform">


### PR DESCRIPTION
> Call to a member function on array()

配列に対してクラスを入れる場合に、push時にメソッドを介して型を指定するとうまく動作します。

エラー元


```
        foreach($this->rules as $rule)
        {
            $vaildResult = $rule->vaild();
            $result = [...$result, ...$vaildResult];
        }
```


上手くいく例
```
    private function addRule(Rule $rule)
    {
        array_push($this->rules,$rule);
    }
```

ダメな例

直接クラスをpushする

```
array_push($this->rules,[
            new TransactionCombinationRule($slip),
        ]);
```
